### PR TITLE
Include PID of emitting process in log lines.

### DIFF
--- a/tmserver/appfactory.py
+++ b/tmserver/appfactory.py
@@ -58,7 +58,7 @@ def create_app(verbosity=None):
 
     """
     log_formatter = logging.Formatter(
-        fmt='%(asctime)s | %(levelname)-8s | %(name)-40s | %(message)s',
+        fmt='[%(process)6d] %(asctime)s | %(levelname)-8s | %(name)-40s | %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
     log_handler = logging.StreamHandler(stream=sys.stdout)


### PR DESCRIPTION
This makes it possible to know which server process generated a given
log line (since there are many and we might want to debug concurrency
issues).