### PR TITLE
Added global identifier to feature and metadata csv downloads

### DIFF
--- a/tmserver/api/feature.py
+++ b/tmserver/api/feature.py
@@ -16,6 +16,7 @@
 """API view functions for querying :mod:`feature <tmlib.models.feature>`
 resources.
 """
+from collections import OrderedDict
 import csv
 import json
 import logging
@@ -535,7 +536,7 @@ def get_metadata(experiment_id, mapobject_type_id):
             for r in results:
                 layer_lut[r.id] = {'tpoint': r.tpoint, 'zplane': r.zplane}
 
-            ref_position_lut = dict()
+            ref_position_lut = OrderedDict()
             if ref_type == 'Plate':
                 results = _get_matching_plates(session, plate_name)
                 for r in results:

--- a/tmserver/api/feature.py
+++ b/tmserver/api/feature.py
@@ -371,7 +371,7 @@ def get_feature_values(experiment_id, mapobject_type_id):
                 filter_by(ref_type=ref_type, id=mapobject_type_id).\
                 one()
 
-        w.writerow(tuple(feature_names))
+        w.writerow(tuple(['mapobject_id'] + feature_names))
         yield data.getvalue()
         data.seek(0)
         data.truncate(0)
@@ -410,7 +410,7 @@ def get_feature_values(experiment_id, mapobject_type_id):
                             mapobject_id
                         )
                         w.writerow(tuple(
-                            [str(np.nan) for x in xrange(len(feature_names))]
+                            [str(np.nan) for x in xrange(len(feature_names) + 1)]
                         ))
                         yield data.getvalue()
                         data.seek(0)
@@ -423,7 +423,7 @@ def get_feature_values(experiment_id, mapobject_type_id):
                     # the corresponding column names.
                     # Feature IDs must be sorted as integers to get the
                     # desired order.
-                    w.writerow(tuple([
+                    w.writerow(tuple([mapobject_id] + [
                         vals[k] for k in sorted(vals, key=lambda k: int(k))
                     ]))
                 yield data.getvalue()
@@ -583,7 +583,7 @@ def get_metadata(experiment_id, mapobject_type_id):
                 order_by(tm.MapobjectType.id).\
                 first()
 
-        w.writerow(tuple(metadata_names + tool_result_names))
+        w.writerow(tuple(['mapobject_id'] + metadata_names + tool_result_names))
         yield data.getvalue()
         data.seek(0)
         data.truncate(0)
@@ -663,7 +663,7 @@ def get_metadata(experiment_id, mapobject_type_id):
                                 v = str(np.nan)
                             tool_result_values.append(v)
                         metadata_values += tool_result_values
-                    w.writerow(tuple(metadata_values))
+                    w.writerow(tuple([mapobject_id] + metadata_values))
                 yield data.getvalue()
                 data.seek(0)
                 data.truncate(0)


### PR DESCRIPTION
To fix https://github.com/TissueMAPS/TissueMAPS/issues/48

Minor edits to include a global map-object identifier in the metadata and feature values downloads. I have the feeling that the ordering of objects in the csv file doesn't always match between the metadata and feature-values files. If I find this to be the case, I'll raise another issue.